### PR TITLE
Deprecate the `@customtype` decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ datatyping
     :target: http://datatyping.readthedocs.io
 
 
-`datatyping` is a pure Python library with no dependencies that you can use to
+``datatyping`` is a pure Python library with no dependencies that you can use to
 verify whether elements in a data structure have the expected types. Great for
 incoming JSON.
 

--- a/datatyping/datatyping.py
+++ b/datatyping/datatyping.py
@@ -5,6 +5,7 @@ __license__ = "MIT"
 
 import collections.abc
 import reprlib
+import warning
 
 
 # Open questions:
@@ -12,17 +13,34 @@ import reprlib
 #     should we handle collections.abc.MappingView?
 
 
-def _make_typeerror(structure, data):
-    error_msg = "%s is of type %s, expected type %s" % (
-        reprlib.repr(data),
-        data.__class__.__name__,
-        structure.__class__.__name__,
+def _make_typeerror(structure, actual_data):
+    if isinstance(structure, type):
+        classname = structure.__name__
+    else:
+        classname = structure.__class__.__name__
+
+    error_msg = '%s is of type %s, expected type %s' % (
+        reprlib.repr(actual_data),
+        actual_data.__class__.__name__,
+        classname
     )
     return TypeError(error_msg)
 
 
+def _make_valueerror(structure, actual_data):
+    error_msg = '%s has the wrong length. Expected %d, got %d.' % (
+        reprlib.repr(actual_data),
+        len(structure),
+        len(actual_data),
+    )
+    return ValueError(error_msg)
+
+
 def customtype(check_function):
     """Decorate a function, so it can be used for type checking.
+
+    Now deprecated, any function or callable can be used for type checking as long
+    as it raises the proper exceptions.
 
     Example
     -------
@@ -45,6 +63,7 @@ def customtype(check_function):
         Function that should be used to type check.
 
     """
+    raise warning.DeprecationWarning('The @customtype decorator is no longer needed')
     check_function.__datatyping_validate = True
     return check_function
 
@@ -66,6 +85,9 @@ def validate(structure, data, *, strict=True):
     ----------
     structure : type or collection of types
         The data structure that `data` should follow.
+        It can also be a function or callable that takes a value and raises exceptions
+        if the check fails. It is highly recommended to follow the exception conventions
+        for this library.
     data : anything
         The data you want type checked.
     strict : bool
@@ -84,36 +106,33 @@ def validate(structure, data, *, strict=True):
         has keys not in `structure`.
 
     """
-    if hasattr(structure, "__datatyping_validate"):
-        structure(data)
-    elif isinstance(structure, collections.abc.Sequence) and not isinstance(data, str):
+    if isinstance(structure, collections.abc.Sequence) and not isinstance(data, str):
         if not isinstance(data, type(structure)):
             raise _make_typeerror(structure, data)
-        if len(structure) == 1:
+
+        if len(structure) == 1:  # All items should be of the same type
             for item in data:
                 validate(structure[0], item, strict=strict)
-            return  # success
-        if len(structure) != len(data):
-            error_msg = ("%s has the wrong length. Expected %d, got %d.") % (
-                reprlib.repr(data),
-                len(structure),
-                len(data),
-            )
-            raise ValueError(error_msg)
-        for type_, item in zip(structure, data):
-            validate(type_, item, strict=strict)
+        elif len(structure) != len(data):
+            raise _make_valueerror(structure, data)
+        else:
+            for type_, item in zip(structure, data):
+                validate(type_, item, strict=strict)
     elif isinstance(structure, collections.abc.Mapping):
         if not isinstance(data, type(structure)):
             raise _make_typeerror(structure, data)
+
         if strict and len(structure) != len(data):
             raise KeyError(reprlib.repr(set(structure.keys()) ^ set(data.keys())))
         for key, type_ in structure.items():
             item = data[key]  # or KeyError :)
             validate(type_, item, strict=strict)
-    elif not isinstance(data, structure):  # structure is a type here
-        error_msg = "%s is of type %s, expected type %s" % (
-            reprlib.repr(data),
-            data.__class__.__name__,
-            structure.__name__,
+    elif isinstance(structure, type):
+        if not isinstance(data, structure):
+            raise _make_typeerror(structure, data)
+    elif callable(structure):
+        structure(data)
+    else:
+        raise TypeError(
+            'The given type mask %s is neither a structure nor a callable' % structure
         )
-        raise TypeError(error_msg)

--- a/datatyping/datatyping.py
+++ b/datatyping/datatyping.py
@@ -5,7 +5,7 @@ __license__ = "MIT"
 
 import collections.abc
 import reprlib
-import warning
+import warnings
 
 
 # Open questions:
@@ -63,7 +63,7 @@ def customtype(check_function):
         Function that should be used to type check.
 
     """
-    raise warning.DeprecationWarning('The @customtype decorator is no longer needed')
+    warnings.warn('The @customtype decorator is no longer needed', DeprecationWarning)
     check_function.__datatyping_validate = True
     return check_function
 

--- a/docs/source/customtype.rst
+++ b/docs/source/customtype.rst
@@ -1,12 +1,14 @@
 Defining Custom Types
 =====================
 
-Special constraints can be imposed with this handy decorater.
+Sometimes, a more specific constraint is required. Such constraints can be imposed by
+passing a callable instead of the type as the type mask.
 
-datatyping.customtype
----------------------
+Make sure that the callable follows the exception conventions for the library:
 
-.. autofunction:: datatyping.customtype
+* A ``TypeError`` is raised when an object does not match the constraint.
+* A ``ValueError`` is raised when the dimensions of the data don't make sense for the type
+  mask
 
 Example
 -------
@@ -16,8 +18,7 @@ integers.
 
 .. code-block:: python
 
-    from datatyping import validate, customtype
-    @customtype
+    from datatyping import validate
     def positive_int(i):
         if i < 1:
             raise TypeError('%d is not positive' % i)
@@ -25,3 +26,9 @@ integers.
     validate([positive_int], [1, 2, 3, 4])
     validate([positive_int], [1, 2, 3, -4])
     TypeError: -4 is not positive
+
+
+datatyping.customtype
+---------------------
+
+.. autofunction:: datatyping.customtype

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,9 @@
 datatyping
 ==========
 
-datatyping is a Python library, that can verify whether data is well-formed.
+``datatyping`` is a Python library that can verify whether data matches the expected type format.
 
-This makes datatyping useful for stuff that is currently hard in Python such
+This makes it useful for stuff that is currently hard in Python such
 as documenting incoming data or testing outgoing data.
 
 .. code-block:: python
@@ -14,13 +14,13 @@ as documenting incoming data or testing outgoing data.
     >>> datatyping.validate(structure, data)
 
 This approach ensures early failure in a specific spot if data is malformed or
-has changed format unexpectedly which results in a more explicit codebase that
+has changed format unexpectedly. This results in a more explicit codebase that
 is easier to maintain.
 
 For more, check out Jeff Knupp's `"How Python Makes Working With Data More
-Difficult in the Long Run" 
+Difficult in the Long Run"
 <https://jeffknupp.com/blog/2016/11/13/how-python-makes-working-with-data-more-difficult-in-the-long-run/>`_
-which inspired this library.
+which has inspired this library.
 
 Installation
 ------------

--- a/docs/source/printer.rst
+++ b/docs/source/printer.rst
@@ -1,8 +1,8 @@
 Structure Generation
 ====================
 
-It can be tedious to type out a structure. Luckily `datatyping` comes with a
-useful submodule for that called `printer`.
+It may be tedious to type out a structure at times. For this purpose, ``datatyping`` comes
+with a useful submodule: ``printer``.
 
 .. code-block:: python
 
@@ -10,12 +10,12 @@ useful submodule for that called `printer`.
     >>> import requests
     >>> r = requests.get('http://httpbin.org/anything')
     >>> pprint(r.json())
-    {   
+    {
         'args': dict,
         'data': str,
         'files': dict,
         'form': dict,
-        'headers': {   
+        'headers': {
             'Accept': str,
             'Accept-Encoding': str,
             'Connection': str,

--- a/docs/source/validate.rst
+++ b/docs/source/validate.rst
@@ -1,7 +1,7 @@
 Getting Started
 ===============
 
-The bread and butter of `datatyping` is the `validate` function.
+The bread and butter of ``datatyping`` is the ``validate`` function.
 
 .. autofunction:: datatyping.validate
 

--- a/tests/test_customtype.py
+++ b/tests/test_customtype.py
@@ -5,32 +5,27 @@ from hypothesis import given, assume
 from hypothesis.strategies import lists, integers, text, one_of, composite, \
     fixed_dictionaries
 
-from datatyping.datatyping import validate, customtype
+from datatyping.datatyping import validate
 
 
-# Custom type definitions
+# Custom checker definitions
 
-
-@customtype
 def positive_int(i):
     if i < 1:
         raise TypeError('%d is negative' % i)
 
 
-@customtype
 def title(s):
     if s != s.title():
         raise TypeError('%s is not a title' % s)
 
 
-@customtype
 def two_item_list(lst):
     if len(lst) != 2:
         raise TypeError('list contains %d items, not 2' % len(lst))
 
 
 # Tests
-
 
 @given(num=integers(min_value=1))
 def test_simple_pos_int(num):


### PR DESCRIPTION
I don't think it's necessary to set attributes for type-checking functions or decorate them in any way.

I've kept the `@customtype` decorator for backwards compatibility, but the `__datatyping_validate` attribute is no longer checked. Now any callable is accepted as a type checker.

I've also refactored the code a bit.

Let me know what you think about this change.